### PR TITLE
fix: let it work with recent mac os versions

### DIFF
--- a/ns_speedtest.sh
+++ b/ns_speedtest.sh
@@ -365,6 +365,10 @@ fi
 
 PingPid=false
 TopPid=false
+
+# On recent Mac OS, ping is not in path anymore
+which ping > /dev/null ||export PATH="$PATH:/sbin"
+
 if [ "$NoFiles" == false ]; then
     eval "ping --apple-time -c${DefaultMaxStats} ${PingDest} >> $OutputFileLatency&"
     PingPid=$!

--- a/ns_speedtest.sh
+++ b/ns_speedtest.sh
@@ -535,10 +535,10 @@ function Analyze() {
     Filter=$1
     shift
 
-    Max=false
-    Min=false
-    Total=false
-    Avg=false
+    Max=-1
+    Min=-1
+    Total=-1
+    Avg=-1
     Index=0
     Count=0
 
@@ -548,7 +548,7 @@ function Analyze() {
 
         if [[ ${DestinationType[$Index]} =~ $Filter ]]
         then
-            if [ "$Max" == false ]
+            if [ "$Max" == "-1" ]
             then
                 Max=$Value
                 Min=$Value


### PR DESCRIPTION
The script has several issues:

1. It is not compatible with recent Mac OS version on which ping is not in $PATH by default, fix that
2. On some systems, the nsconfig file is stored on `/Library/Application Support/Netskope/STAgent/nsconfig.json.enc`, not in `Library/Application Support/Netskope/STAgent/nsconfig.json` => while I could not decode it, I avoided curl to fail with decision by 0 because no AcheckerUrl was found
3. On systems with french locale, print is using decimal separator as ",", not "." => force locale en_US

It is now working with a French locale on recent Mac OS:

```
***** STATISTICS ***** 
Value                         |Average|Maximum|Minimum|   Unit
Throughput tunnel             |   0.00|  -1.00|  -1.00|   Mbps
Throughput gdrive             | 162.85| 207.27| 120.88|   Mbps
End to End Speed tunnel       |   0.00|  -1.00|  -1.00|   Mbps
End to End Speed gdrive       | 110.81| 133.41|  97.60|   Mbps
Time to first byte tunnel     |  0.000| -1.000| -1.000|      s
Time to first byte gdrive     |  2.201|  2.869|  1.578|      s
Download time tunnel          |  0.000| -1.000| -1.000|      s
Download time gdrive          |  5.104|  6.618|  3.860|      s
Total time tunnel             |  0.000| -1.000| -1.000|      s
Total time gdrive             |  7.305|  8.196|  5.996|      s
*** Duration details:
DNS lookup tunnel             |      0|     -1|     -1|     ms
DNS lookup gdrive             |     22|     50|      9|     ms
Connect tunnel                |      0|     -1|     -1|     ms
Connect gdrive                |      3|      4|      2|     ms
App Connect tunnel            |      0|     -1|     -1|     ms
App Connect gdrive            |    107|    227|     44|     ms
Pre Transfer tunnel           |      0|     -1|     -1|     ms
Pre Transfer gdrive           |      0|      0|      0|     ms
Redirect tunnel               |      0|     -1|     -1|     ms
Redirect gdrive               |   1756|   2202|   1040|     ms
Start Transfer tunnel gdrive  |      0|     -1|     -1|     ms
Start Transfer gdrive         |    310|    384|    228|     ms
2023-07-27T00:42:58+02:00 Ending ./ns_speedtest.sh 
*** Latency recording stopped (70252)
*** Cpu recording stopped (70253)
***** END *****
```

=> As you can see, some values are -1, likely because I don't know how to decode `/Library/Application Support/Netskope/STAgent/nsconfig.json.enc`on the system, but the report works